### PR TITLE
ci: only publish on merged PR (not just closed)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   publish:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
See https://shipit.dev/posts/trigger-github-actions-on-pr-close.html