### PR TITLE
Change client generation schedule to 7pm

### DIFF
--- a/.github/workflows/update-client.yml
+++ b/.github/workflows/update-client.yml
@@ -3,7 +3,7 @@ name: Update API client
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 19 * * *"
 
 jobs:
   update-client:


### PR DESCRIPTION
This PR changes the time of the client generation schedule to 7pm (UTC). This way, the client generation runs _before_ the Developer Portal's automatic changelog generation (8pm UTC), and allows new client versions to be picked up for the same day's changelog.