### PR TITLE
Draft: Feat/query object params

### DIFF
--- a/.idea/API Tools.iml
+++ b/.idea/API Tools.iml
@@ -6,6 +6,8 @@
       <excludeFolder url="file://$MODULE_DIR$/packages/generator/dist" />
       <excludeFolder url="file://$MODULE_DIR$/packages/mittwald/dist" />
       <excludeFolder url="file://$MODULE_DIR$/packages/models/dist" />
+      <excludeFolder url="file://$MODULE_DIR$/.nx" />
+      <excludePattern pattern=".pnp.loader.mjs" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/packages/commons/src/core/ParameterSerializer.test.ts
+++ b/packages/commons/src/core/ParameterSerializer.test.ts
@@ -1,0 +1,147 @@
+import { ParamSerializer } from "./ParameterSerializer.js";
+import {
+  QuerySerializationStyles,
+  SerializationOptions,
+} from "../types/index.js";
+
+type SerializerOptions = Record<
+  string,
+  SerializationOptions<QuerySerializationStyles>
+>;
+
+function getDecodedUrlString(serializer: ParamSerializer): string {
+  return decodeURIComponent(serializer.getSearchParams().toString());
+}
+
+describe("QueryParamSerializer", () => {
+  describe("Primitive Values", () => {
+    test.each([
+      {
+        value: "value",
+        expected: "key=value",
+      },
+      {
+        value: 123,
+        expected: "key=123",
+      },
+      {
+        value: true,
+        expected: "key=true",
+      },
+      {
+        value: false,
+        expected: "key=false",
+      },
+    ])("serializes primitive value $value", ({ value, expected }) => {
+      const options: SerializerOptions = {};
+      const serializer = new ParamSerializer(options);
+
+      serializer.serializeQueryParam("key", value);
+
+      expect(getDecodedUrlString(serializer)).toBe(expected);
+    });
+  });
+
+  describe("Array Serialization", () => {
+    test.each([
+      {
+        style: "form",
+        explode: true,
+        expected: "arrayParam=value1&arrayParam=value2",
+      },
+      {
+        style: "form",
+        explode: false,
+        expected: "arrayParam=value1,value2",
+      },
+      {
+        style: "spaceDelimited",
+        explode: false,
+        // URLSearchParams encodes spaces as plus signs (+)
+        // https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#preserving_plus_signs
+        expected: "arrayParam=value1+value2",
+      },
+      {
+        style: "pipeDelimited",
+        explode: false,
+        expected: "arrayParam=value1|value2",
+      },
+    ] as const)(
+      "serializes arrays in $style style with explode=$explode",
+      ({ style, explode, expected }) => {
+        const options: SerializerOptions = {
+          arrayParam: { style, explode },
+        };
+        const serializer = new ParamSerializer(options);
+
+        serializer.serializeQueryParam("arrayParam", ["value1", "value2"]);
+
+        expect(getDecodedUrlString(serializer)).toBe(expected);
+      },
+    );
+
+    test("throws an error for unsupported array serialization styles", () => {
+      const options: SerializerOptions = {
+        arrayParam: { style: "deepObject" },
+      };
+      const serializer = new ParamSerializer(options);
+
+      expect(() => {
+        serializer.serializeQueryParam("arrayParam", ["value1", "value2"]);
+      }).toThrow("Unsupported serialization style for arrays: 'deepObject'");
+    });
+  });
+
+  describe("Object Serialization", () => {
+    test.each([
+      {
+        style: "form",
+        explode: true,
+        expected: "foo=bar&baz=qux",
+      },
+      {
+        style: "form",
+        explode: false,
+        expected: "objectParam=foo,bar,baz,qux",
+      },
+      {
+        style: "deepObject",
+        explode: true,
+        expected: "objectParam[foo]=bar&objectParam[baz]=qux",
+      },
+      {
+        style: "contentJSON",
+        explode: true,
+        expected: 'objectParam={"foo":"bar","baz":"qux"}',
+      },
+    ] as const)(
+      "serializes objects in $style style with explode=$explode",
+      ({ style, explode, expected }) => {
+        const options: SerializerOptions = {
+          objectParam: { style, explode },
+        };
+        const serializer = new ParamSerializer(options);
+
+        serializer.serializeQueryParam("objectParam", {
+          foo: "bar",
+          baz: "qux",
+        });
+
+        expect(getDecodedUrlString(serializer)).toBe(expected);
+      },
+    );
+
+    test("throws an error for unsupported object serialization styles", () => {
+      const options: SerializerOptions = {
+        objectParam: { style: "pipeDelimited" },
+      };
+      const serializer = new ParamSerializer(options);
+
+      expect(() => {
+        serializer.serializeQueryParam("objectParam", { foo: "bar" });
+      }).toThrow(
+        "Unsupported serialization style for objects: 'pipeDelimited'",
+      );
+    });
+  });
+});

--- a/packages/commons/src/core/ParameterSerializer.ts
+++ b/packages/commons/src/core/ParameterSerializer.ts
@@ -1,0 +1,135 @@
+import {
+  QuerySerializationStyles,
+  SerializationOptions,
+} from "../types/index.js";
+
+type QuerySerializationOptions = SerializationOptions<QuerySerializationStyles>;
+
+export class ParamSerializer {
+  private readonly searchParams: URLSearchParams;
+  private readonly options: Record<string, QuerySerializationOptions>;
+
+  constructor(options: Record<string, QuerySerializationOptions>) {
+    this.options = options;
+    this.searchParams = new URLSearchParams();
+  }
+
+  serializeQueryParam(key: string, value: unknown): this {
+    const config = this.options[key];
+
+    switch (true) {
+      case Array.isArray(value):
+        this.handleArraySerialization(key, value, config);
+        break;
+      case typeof value === "object" && value !== null:
+        this.handleObjectSerialization(key, value, config);
+        break;
+      default:
+        this.handlePrimitiveSerialization(key, value);
+    }
+
+    return this;
+  }
+
+  getSearchParams(): URLSearchParams {
+    return this.searchParams;
+  }
+
+  private handlePrimitiveSerialization(key: string, value: unknown): void {
+    this.searchParams.append(key, String(value));
+  }
+
+  private handleArraySerialization(
+    key: string,
+    value: unknown[],
+    styleOptions: QuerySerializationOptions = { style: "form", explode: true },
+  ): void {
+    const { style, explode = true } = styleOptions;
+
+    switch (style) {
+      case "form":
+        this.serializeArrayForm(key, value, explode);
+        break;
+      case "spaceDelimited":
+        this.serializeArrayDelimited(key, value, " ");
+        break;
+      case "pipeDelimited":
+        this.serializeArrayDelimited(key, value, "|");
+        break;
+      default:
+        throw new Error(
+          `Unsupported serialization style for arrays: '${style}'`,
+        );
+    }
+  }
+
+  private serializeArrayForm(
+    key: string,
+    value: unknown[],
+    explode: boolean,
+  ): void {
+    if (explode) {
+      value.forEach((item) => this.searchParams.append(key, String(item)));
+    } else {
+      this.serializeArrayDelimited(key, value, ",");
+    }
+  }
+
+  private serializeArrayDelimited(
+    key: string,
+    value: unknown[],
+    delimiter: string,
+  ): void {
+    this.searchParams.append(key, value.join(delimiter));
+  }
+
+  private handleObjectSerialization(
+    key: string,
+    value: object,
+    styleOptions: QuerySerializationOptions = {
+      style: "deepObject",
+      explode: true,
+    },
+  ): void {
+    const { style, explode = true } = styleOptions;
+
+    switch (style) {
+      case "form":
+        this.serializeObjectForm(key, value, explode);
+        break;
+      case "deepObject":
+        this.serializeObjectDeepObject(key, value);
+        break;
+      case "contentJSON":
+        this.searchParams.append(key, JSON.stringify(value));
+        break;
+      default:
+        throw new Error(
+          `Unsupported serialization style for objects: '${style}'`,
+        );
+    }
+  }
+
+  private serializeObjectForm(
+    key: string,
+    value: object,
+    explode: boolean,
+  ): void {
+    if (explode) {
+      Object.entries(value).forEach(([k, v]) =>
+        this.searchParams.append(k, String(v)),
+      );
+    } else {
+      const serialized = Object.entries(value)
+        .map(([k, v]) => `${k},${v}`)
+        .join(",");
+      this.searchParams.append(key, serialized);
+    }
+  }
+
+  private serializeObjectDeepObject(key: string, value: object): void {
+    Object.entries(value).forEach(([k, v]) =>
+      this.searchParams.append(`${key}[${k}]`, String(v)),
+    );
+  }
+}

--- a/packages/commons/src/types/OpenAPIOperation.ts
+++ b/packages/commons/src/types/OpenAPIOperation.ts
@@ -2,6 +2,17 @@ import { AnyResponse, Response } from "./Response.js";
 import { AnyRequest, RequestType } from "./RequestType.js";
 import { HttpMethod, HttpStatus } from "./http.js";
 
+export type QuerySerializationStyles =
+  | "form"
+  | "spaceDelimited"
+  | "pipeDelimited"
+  | "deepObject"
+  | "contentJSON";
+export interface SerializationOptions<TStyle extends string> {
+  style: TStyle;
+  explode?: boolean;
+}
+
 export interface OpenAPIOperation<
   TIgnoredRequest extends AnyRequest = RequestType,
   IgnoredResponse extends AnyResponse = Response,
@@ -9,6 +20,9 @@ export interface OpenAPIOperation<
   operationId: string;
   path: string;
   method: HttpMethod;
+  serialization?: {
+    query?: Record<string, SerializationOptions<QuerySerializationStyles>>;
+  };
 }
 
 export type InferredRequestType<TOp> =

--- a/packages/commons/src/types/RequestType.ts
+++ b/packages/commons/src/types/RequestType.ts
@@ -29,7 +29,7 @@ type RequestWithHeaders<THeaders> = THeaders extends EmptyRequestComponent
 type RequestWithQueryParameters<TQuery> = TQuery extends EmptyRequestComponent
   ? RequestWithOptionalHeaders
   : {
-      queryParameters: TQuery & HttpHeaders;
+      queryParameters: TQuery & QueryParameters;
     };
 
 export type RequestType<


### PR DESCRIPTION
see https://swagger.io/docs/specification/v3_0/serialization/#query-parameters

- [x] Support in request handling
- [ ] Adjustments to client generator to write `serialization`-Options according to given OpenAPI schema