### PR TITLE
fix(Generation): fix generated types for security HTTP scheme

### DIFF
--- a/packages/generator/src/generation/model/components/SecurityScheme.ts
+++ b/packages/generator/src/generation/model/components/SecurityScheme.ts
@@ -3,6 +3,10 @@ import { Name } from "../global/Name.js";
 import { SecuritySchemes } from "./SecuritySchemes.js";
 import { JSONSchema } from "../global/JSONSchema.js";
 
+export type SecuritySchemeType =
+  | OpenAPIV3.ApiKeySecurityScheme
+  | OpenAPIV3.HttpSecurityScheme;
+
 export class SecurityScheme {
   public readonly in: string;
   public readonly name: Name;
@@ -11,19 +15,21 @@ export class SecurityScheme {
   public constructor(
     schemes: SecuritySchemes,
     name: string,
-    doc: OpenAPIV3.ApiKeySecurityScheme,
+    doc: SecuritySchemeType,
   ) {
     this.name = new Name(name, schemes.name);
-    this.in = doc.in;
+    this.in = doc.type === "http" ? "header" : doc.in;
+
+    const propName = doc.type === "http" ? "Authorization" : doc.name;
     this.jsonSchema = new JSONSchema(this.name, {
       type: "object",
       description: doc.description,
       properties: {
-        [doc.name]: {
+        [propName]: {
           type: "string",
         },
       },
-      required: [doc.name],
+      required: [propName],
     });
   }
 }

--- a/packages/generator/src/generation/model/components/SecuritySchemes.ts
+++ b/packages/generator/src/generation/model/components/SecuritySchemes.ts
@@ -4,7 +4,7 @@ import { OpenAPIV3 } from "openapi-types";
 import invariant from "invariant";
 import { assertNoRefs } from "../../refs/assertNoRefs.js";
 import { asyncStringJoin } from "../../asyncStringJoin.js";
-import { SecurityScheme } from "./SecurityScheme.js";
+import { SecurityScheme, type SecuritySchemeType } from "./SecurityScheme.js";
 import { TypeCompilationOptions } from "../CodeGenerationModel.js";
 
 export class SecuritySchemes {
@@ -31,11 +31,7 @@ export class SecuritySchemes {
 
     this.schemes = Object.entries(doc).map(
       ([name, scheme]) =>
-        new SecurityScheme(
-          this,
-          name,
-          scheme as OpenAPIV3.ApiKeySecurityScheme,
-        ),
+        new SecurityScheme(this, name, scheme as SecuritySchemeType),
     );
   }
 


### PR DESCRIPTION
The resulting type for the mittwald API will be like this

```typescript
      /**
       * 'Authorization: Bearer xyz' is required
       */
      export interface CommonsLegacyBearerAuthentication {
        undefined?: string;
      }
```

This fix sets the header name to `Authorization` when using `http` type.