### PR TITLE
Remove version file generation from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
       - master
       - dev
   workflow_run:
-    workflows: 
+    workflows:
       - Update API client
       - Update API client (dev)
     types:
@@ -22,8 +22,10 @@ permissions:
 jobs:
   publish:
     if:
-       (github.event.workflow_run.name == 'Update API client' || github.event.pull_request.base.ref == 'master') && 
-       (github.event.pull_request.merged == true || github.event.workflow_run.conclusion == 'success')
+      (github.event.workflow_run.name == 'Update API client' ||
+      github.event.pull_request.base.ref == 'master') &&
+      (github.event.pull_request.merged == true ||
+      github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
 
     env:
@@ -68,12 +70,6 @@ jobs:
       - name: Build 🔨
         run: yarn nx affected -t build --parallel=3
 
-      # TODO: Uses the previous version. Needs a fix!
-      - name: Create version file 🔢
-        run: |
-          yarn nx run @mittwald/api-client:build:write-version-file
-          git add .
-
       - name: Version and publish 🚀
         if:
           github.event.workflow_run.head_branch == 'master' || github.ref ==
@@ -90,10 +86,10 @@ jobs:
               --tag-version-prefix ""
           fi
 
-
   publish-dev:
     if:
-       github.event.workflow_run.name == 'Update API client (dev)' && github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.name == 'Update API client (dev)' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     env:
@@ -138,12 +134,6 @@ jobs:
 
       - name: Build 🔨
         run: yarn nx affected -t build --parallel=3
-
-      # TODO: Uses the previous version. Needs a fix!
-      - name: Create version file 🔢
-        run: |
-          yarn nx run @mittwald/api-client:build:write-version-file
-          git add .
 
       - name: Version and publish 🚀
         run: |

--- a/nx.json
+++ b/nx.json
@@ -17,7 +17,7 @@
       "dependsOn": ["^build"]
     },
     "build:write-version-file": {
-      "cache": true,
+      "cache": false,
       "dependsOn": ["build"]
     },
     "lint": {

--- a/packages/mittwald/dev/writeVersion.ts
+++ b/packages/mittwald/dev/writeVersion.ts
@@ -2,7 +2,9 @@ import { readPackage } from "read-pkg";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-const { version } = await readPackage();
+const { version } = await readPackage({
+  cwd: path.join(import.meta.dirname, ".."),
+});
 
 const distFolder = path.join(import.meta.dirname, "../dist");
 

--- a/packages/mittwald/package.json
+++ b/packages/mittwald/package.json
@@ -43,7 +43,8 @@
     "lint": "run eslint .",
     "test": "",
     "test:client-generation-clean": "git diff --exit-code",
-    "test:compile": "run tsc --noEmit"
+    "test:compile": "run tsc --noEmit",
+    "version": "run build:write-version-file"
   },
   "dependencies": {
     "@mittwald/api-client-commons": "workspace:^",


### PR DESCRIPTION
## Summary
- Remove the inline version file generation step from the publish workflows
- Disable Nx caching for `build:write-version-file` so the task always runs when invoked
- Make version resolution in `writeVersion.ts` explicit by reading from the package directory
- Add a package `version` script that delegates to `build:write-version-file`

## Testing
- Not run (not requested)